### PR TITLE
Back to original French translation inside code examples

### DIFF
--- a/translations/book/fr.po
+++ b/translations/book/fr.po
@@ -1709,6 +1709,9 @@ msgid ""
 msgstr ""
 "Fichier : src/main.rs"
 
+msgid "<uspan class=\"filename\">Filename: src/main.rs</span>"
+msgstr "<span class=\"filename\">Fichier : src/main.rs</span>"
+
 # msgid ""
 # "<span class=\"filename\">Filename: main.rs</span>"
 # msgstr ""
@@ -2717,46 +2720,13 @@ msgstr ""
 "vous avez créé au chapitre 1 et utilisez Cargo pour créer votre projet, "
 "comme ceci :"
 
-# # Terminal output: {{{
-#
-# # msgid "$ cargo new guessing_game"
-# # msgstr "$ cargo new jeu_du_plus_ou_du_moins"
-#
-# # msgid ""
-# # "$ cargo new guessing_game\n"
-# # "$ cd guessing_game\n"
-# # msgstr ""
-# # "$ cargo jeu_du_plus_ou_du_moins\n"
-# # "$ cd jeu_du_plus_ou_du_moins\n"
-#
-# # msgid ""
-# # "```console\n"
-# # "$ cargo new guessing_game\n"
-# # "$ cd guessing_game\n"
-# # "```"
-# # msgstr ""
-# # "```console\n"
-# # "$ cargo jeu_du_plus_ou_du_moins\n"
-# # "$ cd jeu_du_plus_ou_du_moins\n"
-# # "```"
-#
-# # "```"
-# # "```toml\n"
-# # "[package]\n"
-# # "name = \"jeu_du_plus_ou_du_moins\"\n"
-# # "version = \"0.1.0\"\n"
-# # "edition = \"2024\"\n"
-# # "\n"
-# # "[dependencies]\n"
-# # "```"
-#
-# # @# FIXME: the terminal translations above do not seem to work as expected;
-# #        therefore, terminal outputs and text do not match
+# Terminal output:
 
-# NOTE: For the time being, leave console and code untranslated, and revert
-#       translations in text body, until a solution to translate code can be
-#       found.
-# }}}
+msgid "$ cargo new guessing_game"
+msgstr "$ cargo new jeu_du_plus_ou_du_moins"
+
+msgid "$ cd guessing_game"
+msgstr "$ cd jeu_du_plus_ou_du_moins"
 
 #: src/ch02-00-guessing-game-tutorial.md:26
 msgid ""
@@ -2765,14 +2735,8 @@ msgid ""
 "new project’s directory."
 msgstr ""
 "La première commande, `cargo new`, prend comme premier argument le nom de "
-"notre projet (`"
-"guessing_game"
-"`). La seconde commande nous déplace "
+"notre projet (`jeu_du_plus_ou_du_moins`). La seconde commande nous déplace "
 "dans le répertoire de notre nouveau projet créé par Cargo."
-
-# "jeu_du_plus_ou_du_moins
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
-
 
 #: src/ch02-00-guessing-game-tutorial.md:30
 msgid "Look at the generated _Cargo.toml_ file:"
@@ -2788,45 +2752,9 @@ msgstr "Regardons le fichier Cargo.toml qui a été généré :"
 msgid "<span class=\"filename\">Filename: Cargo.toml</span>"
 msgstr "<span class=\"filename\">Fichier : Cargo.toml</span>"
 
-msgid "<span class=\"filename\">Filename: src/Cargo.toml</span>"
-msgstr "<span class=\"filename\">Fichier : src/Cargo.toml</span>"
-
-
-# @# TODO: the previous legend is properly translated: apply the same method for
-#          previous cases which failed
-# @# FIXME: for some reason, the previous legend is no longer translated...
-# Desperate tries:{{{
-
-msgid "<span class=\"file-name\">Filename: Cargo.toml</span>"
-msgstr "<span class=\"file-name\">Fichier : Cargo.toml</span>"
-
-msgid "<p><span class=\"filename\">Filename: Cargo.toml</span></p>"
-msgstr "<p><span class=\"file-name\">Fichier : Cargo.toml</span></p>"
-
-# }}}
-
 #: src/ch02-00-guessing-game-tutorial.md:43
-msgid ""
-"```toml\n"
-"[package]\n"
-"name = \"guessing_game\"\n"
-"version = \"0.1.0\"\n"
-"edition = \"2024\"\n"
-"\n"
-"[dependencies]\n"
-"```"
-msgstr ""
-
-# "```toml\n"
-# "[package]\n"
-# "name = \"jeu_du_plus_ou_du_moins\"\n"
-# "version = \"0.1.0\"\n"
-# "edition = \"2024\"\n"
-# "\n"
-# "[dependencies]\n"
-# "```"
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
-
+msgid "name = \"guessing_game\""
+msgstr "name = \"jeu_du_plus_ou_du_moins\""
 
 #: src/ch02-00-guessing-game-tutorial.md:52
 msgid ""
@@ -2846,25 +2774,11 @@ msgstr ""
 "exécution en une seule commande avec `cargo run` :"
 
 #: src/ch02-00-guessing-game-tutorial.md:66
-msgid ""
-"```console\n"
-"$ cargo run\n"
-"   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s\n"
-"     Running `target/debug/guessing_game`\n"
-"Hello, world!\n"
-"```"
-msgstr ""
+msgid "   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)"
+msgstr "   Compiling jeu_du_plus_ou_du_moins v0.1.0 (file:///projects/jeu_du_plus_ou_du_moins)"
 
-# "```console\n"
-# "$ cargo run\n"
-# "   Compiling jeu_du_plus_ou_du_moins v0.1.0 (file:///projects/jeu_du_plus_ou_du_moins)\n"
-# "    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s\n"
-# "     Running `target/debug/jeu_du_plus_ou_du_moins`\n"
-# "Hello, world!\n"
-# "```"
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
-
+msgid "     Running `target/debug/guessing_game`"
+msgstr "     Running `target/debug/jeu_du_plus_ou_du_moins`"
 
 #: src/ch02-00-guessing-game-tutorial.md:74
 msgid ""
@@ -2898,6 +2812,7 @@ msgstr ""
 "texte, à traiter cette saisie, et à vérifier que la saisie correspond au "
 "format attendu. Commençons par permettre au joueur de saisir son nombre. "
 "Entrez le code de l'encart 2-1 dans le fichier _src/main.rs_."
+
 
 #: src/ch02-00-guessing-game-tutorial.md:93
 #: src/ch02-00-guessing-game-tutorial.md:118
@@ -2945,13 +2860,16 @@ msgstr "\"Devinez le nombre !\""
 msgid "\"Please input your guess.\""
 msgstr "\"Veuillez entrer un nombre.\""
 
-# Attempt to translate a variable name located inside the code:
-msgid "guess"
-msgstr "supposition"
+# Lines of code which need translation:
+msgid "    let mut guess = String::new();"
+msgstr "    let mut supposition = String::new();"
 
-# @# FIXME how to translate variables in code, so as to match the text; the
-#       legacy French translation has variables, traits, structs, etc. names
-#       translated in French, which is very pedagogic.
+msgid "        let mut guess = String::new();"
+msgstr "        let mut supposition = String::new();"
+
+msgid "        .read_line(&mut guess)"
+msgstr "        .read_line(&mut supposition)"
+
 
 #: src/ch02-00-guessing-game-tutorial.md:101
 #: src/ch02-00-guessing-game-tutorial.md:126
@@ -2974,8 +2892,8 @@ msgstr "supposition"
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:407
 #: src/ch09-03-to-panic-or-not-to-panic.md:179
 #: src/ch20-03-advanced-types.md:252
-msgid "\"Failed to read line\""
-msgstr "\"Échec de la lecture de l'entrée utilisateur\""
+# msgid "\"Failed to read line\""
+# msgstr "\"Échec de la lecture de l'entrée utilisateur\""
 
 #: src/ch02-00-guessing-game-tutorial.md:103
 #: src/ch02-00-guessing-game-tutorial.md:128
@@ -2997,11 +2915,7 @@ msgstr "\"Échec de la lecture de l'entrée utilisateur\""
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:411
 #: src/ch20-03-advanced-types.md:259
 msgid "\"You guessed: {guess}\""
-msgstr "\"Votre nombre : {guess}\""
-
-# msgstr "\"Votre nombre : {supposition}\""
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
-
+msgstr "\"Votre nombre : {supposition}\""
 
 #: src/ch02-00-guessing-game-tutorial.md:109
 msgid ""
@@ -3086,13 +3000,6 @@ msgstr ""
 "Ensuite, on crée une _variable_ pour stocker la saisie de l'utilisateur, comme "
 "ceci :"
 
-# @# FIXME translate variables' names in code:
-# Attempt to translate a variable name located inside the code:
-msgid  "    let mut guess = String::new();"
-msgstr "    let mut supposition = String::new();"
-
-
-
 #: src/ch02-00-guessing-game-tutorial.md:211
 msgid ""
 "Now the program is getting interesting! There’s a lot going on in this "
@@ -3103,13 +3010,8 @@ msgstr ""
 "dans cette petite ligne. Nous utilisons l'instruction `let` pour créer la "
 "variable. Voici un autre exemple :"
 
-# @# FIXME translate variables' names in code:
-msgid "let apples = 5;\n"
-msgstr ""
-
-# let pommes = 5;\n"
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
-
+msgid "let apples = 5;"
+msgstr "let pommes = 5;"
 
 #: src/ch02-00-guessing-game-tutorial.md:218
 msgid ""
@@ -3121,7 +3023,7 @@ msgid ""
 "3. To make a variable mutable, we add `mut` before the variable name:"
 msgstr ""
 "Cette ligne permet de créer une nouvelle variable nommée `"
-"apples"
+"pommes"
 "` et à lui "
 "assigner la valeur `5`. Par défaut en Rust, les variables sont immuables, ce "
 "qui implique qu'à partir du moment où l'on donne une valeur à une variable, "
@@ -3131,17 +3033,11 @@ msgstr ""
 " <!-- ignore -->  au chapitre 3. Pour rendre une variable mutable "
 "_(c'est-à-dire modifiable)_, nous ajoutons `mut` devant le nom de la variable :"
 
-# "pommmes"
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
+msgid "let apples = 5; // immutable"
+msgstr "let pommes = 5; // immuable"
 
-
-#: src/ch02-00-guessing-game-tutorial.md:226
-msgid "// immutable\n"
-msgstr "// immuable\n"
-
-#: src/ch02-00-guessing-game-tutorial.md:227
-msgid "// mutable\n"
-msgstr "// mutable, modifiable"
+msgid "let mut bananas = 5; // mutable"
+msgstr "let mut bananes = 5; // mutable, modifiable"
 
 #: src/ch02-00-guessing-game-tutorial.md:230
 msgid ""
@@ -3167,26 +3063,20 @@ msgid ""
 msgstr ""
 "Lorsque vous revenez sur le jeu du plus ou du moins, vous comprenez donc "
 "maintenant que la ligne `let mut "
-"guess"
+"supposition"
 "` permet de créer une variable "
 "mutable nommée `"
-"guess"
+"supposition"
 "`. Le signe égal (`=`) indique à Rust que nous "
 "voulons désormais lier quelquechose à la variable. À la droite du signe "
 "égal, nous avons la valeur liée à `"
-"guess"
+"supposition"
 "`, qui est ici le résultat de "
 "l'utilisation de `String::new`, qui est une fonction qui retourne une "
 "nouvelle instance de `String`. [`String`](../std/string/struct.String.html)"
 "<!-- ignore --> est un type "
 "de chaîne de caractères fourni par la bibliothèque standard, qui est une "
 "portion de texte encodée en UTF-8 et dont la longueur peut augmenter."
-
-# "supposition"
-# "supposition"
-# "supposition"
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
-
 
 #: src/ch02-00-guessing-game-tutorial.md:242
 msgid ""
@@ -3210,14 +3100,10 @@ msgid ""
 "Whew!"
 msgstr ""
 "En définitif, la ligne `let mut "
-"guess"
+"supposition"
 " = String::new();` crée une "
 "nouvelle variable mutable qui contient une nouvelle chaîne de caractères "
 "vide, une instance de `String`. Ouf !"
-
-# "supposition"
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
-
 
 #: src/ch02-00-guessing-game-tutorial.md:251
 msgid "Receiving User Input"
@@ -3264,12 +3150,12 @@ msgid ""
 "can change the string’s content."
 msgstr ""
 "Ensuite, la ligne `.read_line(&mut "
-"guess"
+"supposition"
 ")` appelle la méthode "
 "[`read_line`](../std/io/struct.Stdin.html#method.read_line)"
 "<!-- ignore --> sur l'entrée standard afin d'obtenir "
 "la saisie utilisateur. Nous passons aussi `&mut "
-"guess"
+"supposition"
 "` en argument de "
 "`read_line` pour lui indiquer dans quelle chaîne de caractère il faut "
 "stocker la saisie utilisateur. Le but final de `read_line` est de récupérer "
@@ -3277,10 +3163,6 @@ msgstr ""
 "fin d'une chaîne de caractères (sans écraser son contenu) ; c'est pourquoi "
 "nous passons cette chaîne de caractères en argument. Cet argument doit être "
 "mutable pour que `read_line` puisse en modifier le contenu."
-
-# "supposition"
-# "supposition"
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
 
 #: src/ch02-00-guessing-game-tutorial.md:291
 msgid ""
@@ -3303,16 +3185,11 @@ msgstr ""
 "programme. Pour l'instant, tout ce que vous devez savoir est que, comme les "
 "variables, les références sont immuables par défaut. D'où la nécessité "
 "d'écrire `&mut "
-"guess"
+"supposition"
 "` au lieu de `&"
-"guess"
+"supposition"
 "` pour la rendre "
 "mutable. (Le chapitre 4 expliquera plus en détail les références.)"
-
-# "supposition"
-# "supposition"
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
-
 
 # #: src/ch02-00-guessing-game-tutorial.md:303
 # #, fuzzy
@@ -3334,10 +3211,35 @@ msgstr ""
 "d'une seule ligne de code logique. La prochaine partie rajoute cette "
 "méthode :"
 
+msgid "        .expect(\"Failed to read line\");"
+msgstr "        .expect(\"Échec de la lecture de l'entrée utilisateur\");"
+
+msgid "            .expect(\"Failed to read line\");"
+msgstr "            .expect(\"Échec de la lecture de l'entrée utilisateur\");"
+
 #: src/ch02-00-guessing-game-tutorial.md:329
 msgid "We could have written this code as:"
 msgstr ""
 "Nous aurions pu écrire ce code de cette manière :"
+
+msgid "io::stdin().read_line(&mut guess).expect(\"Failed to read line\");"
+msgstr "io::stdin().read_line(&mut supposition).expect(\"Échec de la lecture de l'entrée utilisateur\");"
+
+# Double translation, side-effect of preprocessing:
+# msgid "    let guess: u32 = guess.trim().parse().expect(\"Veuillez entrer un nombre !\");"
+# msgstr "    let supposition: u32 = supposition.trim().parse().expect(\"Veuillez entrer un nombre !\");"
+# 
+# msgid "let guess: u32 = guess.trim().parse().expect(\"Veuillez entrer un nombre !\");"
+# msgstr "    let supposition: u32 = supposition.trim().parse().expect(\"Veuillez entrer un nombre !\");"
+
+msgid "let guess: u32 = guess.trim().parse().expect(\"Please type a number!\");"
+msgstr "    let supposition: u32 = supposition.trim().parse().expect(\"Veuillez entrer un nombre !\");"
+
+msgid "    let guess: u32 = guess.trim().parse().expect(\"Please type a number!\");"
+msgstr "    let supposition: u32 = supposition.trim().parse().expect(\"Veuillez entrer un nombre !\");"
+
+msgid "        let guess: u32 = guess.trim().parse().expect(\"Please type a number!\");"
+msgstr "        let supposition: u32 = supposition.trim().parse().expect(\"Veuillez entrer un nombre !\");"
 
 #: src/ch02-00-guessing-game-tutorial.md:335
 msgid ""
@@ -3425,27 +3327,23 @@ msgstr ""
 "Si on n'appelle pas expect, le programme compilera, mais avec un avertissement :"
 
 #: src/ch02-00-guessing-game-tutorial.md:366
-msgid ""
-"```console\n"
-"$ cargo build\n"
-"   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"warning: unused `Result` that must be used\n"
-"  --> src/main.rs:10:5\n"
-"   |\n"
-"10 |     io::stdin().read_line(&mut guess);\n"
-"   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
-"   |\n"
-"   = note: this `Result` may be an `Err` variant, which should be handled\n"
-"   = note: `#[warn(unused_must_use)]` on by default\n"
-"help: use `let _ = ...` to ignore the resulting value\n"
-"   |\n"
-"10 |     let _ = io::stdin().read_line(&mut guess);\n"
-"   |     +++++++\n"
-"\n"
-"warning: `guessing_game` (bin \"guessing_game\") generated 1 warning\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.59s\n"
-"```"
-msgstr ""
+# msgid ""
+# "   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)"
+# msgstr ""
+# "   Compiling jeu_du_plus_ou_du_moins v0.1.0 (file:///projects/jeu_du_plus_ou_du_moins)"
+
+msgid "10 |     io::stdin().read_line(&mut guess);"
+msgstr "10 |     io::stdin().read_line(&mut supposition);"
+
+msgid "   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+msgstr "   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^"
+
+
+msgid "10 |     let _ = io::stdin().read_line(&mut guess);"
+msgstr "10 |     let _ = io::stdin().read_line(&mut supposition);"
+
+msgid "warning: `guessing_game` (bin \"guessing_game\") generated 1 warning"
+msgstr "warning: `jeu_du_plus_ou_du_moins` (bin \"jeu_du_plus_ou_du_moins\") generated 1 warning"
 
 #: src/ch02-00-guessing-game-tutorial.md:386
 msgid ""
@@ -3508,19 +3406,11 @@ msgstr ""
 
 #: src/ch02-00-guessing-game-tutorial.md:430
 msgid "\"x = {x} and y + 2 = {}\""
-msgstr ""
-
-# msgstr "\"x = {x} et y + 2 = {}\""
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
-
+msgstr "\"x = {x} et y + 2 = {}\""
 
 #: src/ch02-00-guessing-game-tutorial.md:433
 msgid "This code would print `x = 5 and y + 2 = 12`."
-msgstr "Ce code afficherait `x = 5 and y + 2 = 12`."
-
-# msgstr "Ce code afficherait `x = 5 et y + 2 = 12`."
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
-
+msgstr "Ce code afficherait `x = 5 et y + 2 = 12`."
 
 #: src/ch02-00-guessing-game-tutorial.md:435
 msgid "Testing the First Part"
@@ -3533,29 +3423,11 @@ msgstr ""
 "Pour tester notre début de programme, lançons-le à l'aide de la commande "
 "`cargo run` :"
 
+
 #: src/ch02-00-guessing-game-tutorial.md:445
-msgid ""
-"```console\n"
-"$ cargo run\n"
-"   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.44s\n"
-"     Running `target/debug/guessing_game`\n"
-"Guess the number!\n"
-"Please input your guess.\n"
-"6\n"
-"You guessed: 6\n"
-"```"
-msgstr ""
-"```console\n"
-"$ cargo run\n"
-"   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.44s\n"
-"     Running `target/debug/guessing_game`\n"
-"Devinez le nombre !\n"
-"Veuillez entrer un nombre.\n"
-"6\n"
-"Votre nombre : 6\n"
-"```"
+msgid "You guessed: 6"
+msgstr "Votre nombre : 6"
+
 
 #: src/ch02-00-guessing-game-tutorial.md:456
 msgid ""
@@ -3681,33 +3553,13 @@ msgstr ""
 "compilation du projet, comme dans l'encart 2-2 :"
 
 #: src/ch02-00-guessing-game-tutorial.md:525
-msgid ""
-"```console\n"
-"$ cargo build\n"
-"  Updating crates.io index\n"
-"   Locking 15 packages to latest Rust 1.85.0 compatible versions\n"
-"    Adding rand v0.8.5 (available: v0.9.0)\n"
-" Compiling proc-macro2 v1.0.93\n"
-" Compiling unicode-ident v1.0.17\n"
-" Compiling libc v0.2.170\n"
-" Compiling cfg-if v1.0.0\n"
-" Compiling byteorder v1.5.0\n"
-" Compiling getrandom v0.2.15\n"
-" Compiling rand_core v0.6.4\n"
-" Compiling quote v1.0.38\n"
-" Compiling syn v2.0.98\n"
-" Compiling zerocopy-derive v0.7.35\n"
-" Compiling zerocopy v0.7.35\n"
-" Compiling ppv-lite86 v0.2.20\n"
-" Compiling rand_chacha v0.3.1\n"
-" Compiling rand v0.8.5\n"
-" Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"  Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.48s\n"
-"```"
-msgstr ""
+msgid " Compiling guessing_game v0.1.0 (file:///projects/guessing_game)"
+msgstr " Compiling jeu_du_plus_ou_du_moins v0.1.0 (file:///projects/jeu_du_plus_ou_du_moins)"
 
-# " Compiling jeu_du_plus_ou_du_moins v0.1.0 (file:///projects/guessing_game)\n"
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
+msgid "Listing 2-2: The output from running cargo build after adding the rand crate as a dependency"
+msgstr "Encart 2-2 : Résultat du lancement de cargo build après avoir ajouté la crate rand comme dépendance"
+
+# FIXME Legend above does not translate
 
 
 #: src/ch02-00-guessing-game-tutorial.md:550
@@ -3776,14 +3628,14 @@ msgstr ""
 "enregistrez le fichier, et relancez la compilation, vous verrez s'afficher "
 "uniquement deux lignes :"
 
-#: src/ch02-00-guessing-game-tutorial.md:580
-msgid ""
-"```console\n"
-"$ cargo build\n"
-"   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s\n"
-"```"
-msgstr ""
+# #: src/ch02-00-guessing-game-tutorial.md:580
+# msgid ""
+# "```console\n"
+# "$ cargo build\n"
+# "   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
+# "    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s\n"
+# "```"
+# msgstr ""
 
 #: src/ch02-00-guessing-game-tutorial.md:586
 msgid ""
@@ -3890,13 +3742,13 @@ msgstr ""
 "comme ceci (ne faites pas réellement ce changement, car les exemples "
 "suivants supposent que vous utilisez `rand` 0.8) :"
 
-#: src/ch02-00-guessing-game-tutorial.md:644
-msgid ""
-"```toml\n"
-"[dependencies]\n"
-"rand = \"0.999.0\"\n"
-"```"
-msgstr ""
+# #: src/ch02-00-guessing-game-tutorial.md:644
+# msgid ""
+# "```toml\n"
+# "[dependencies]\n"
+# "rand = \"0.999.0\"\n"
+# "```"
+# msgstr ""
 
 #: src/ch02-00-guessing-game-tutorial.md:649
 msgid ""
@@ -3949,12 +3801,18 @@ msgstr ""
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:399
 #: src/ch20-03-advanced-types.md:241
 msgid "\"The secret number is: {secret_number}\""
-msgstr "\"Le nombre secret est : {nombre_secret}\""
+msgstr "\"Le nombre secret est : {nombre_secret}\""
 
 msgid ": Adding code to generate a random number"
 msgstr " : Ajout du code pour générer un nombre aléatoire"
 
+msgid "Listing 2-3: Adding code to generate a random number"
+msgstr "Encart 2-3 : Ajout du code pour générer un nombre aléatoire"
+
 # FIXME: the legends as the one above are not translated
+
+msgid "    let secret_number = rand::thread_rng().gen_range(1..=100);"
+msgstr "    let nombre_secret = rand::thread_rng().gen_range(1..=100);"
 
 #: src/ch02-00-guessing-game-tutorial.md:692
 msgid ""
@@ -4031,48 +3889,24 @@ msgid "Try running the program a few times:"
 msgstr "Essayez de lancer le programme plusieurs fois :"
 
 #: src/ch02-00-guessing-game-tutorial.md:730
-msgid ""
-"```console\n"
-"$ cargo run\n"
-"   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s\n"
-"     Running `target/debug/guessing_game`\n"
-"Guess the number!\n"
-"The secret number is: 7\n"
-"Please input your guess.\n"
-"4\n"
-"You guessed: 4\n"
-"\n"
-"$ cargo run\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s\n"
-"     Running `target/debug/guessing_game`\n"
-"Guess the number!\n"
-"The secret number is: 83\n"
-"Please input your guess.\n"
-"5\n"
-"You guessed: 5\n"
-"```"
-msgstr ""
-"```console\n"
-"$ cargo run\n"
-"   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s\n"
-"     Running `target/debug/guessing_game`\n"
-"Devinez le nombre !\n"
-"Le nombre secret est :  7\n"
-"Veuillez entrer un nombre.\n"
-"4\n"
-"Votre nombre : 4\n"
-"\n"
-"$ cargo run\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.02s\n"
-"     Running `target/debug/guessing_game`\n"
-"Devinez le nombre !\n"
-"Le nombre secret est : 83\n"
-"Veuillez entrer un nombre.\n"
-"5\n"
-"Votre nombre : 5\n"
-"```"
+msgid "Guess the number!"
+msgstr "Devinez le nombre !"
+
+msgid "The secret number is: 7"
+msgstr "Le nombre secret est : 7"
+
+msgid "Please input your guess."
+msgstr "Veuillez entrer un nombre."
+
+msgid "You guessed: 4"
+msgstr "Votre nombre : 4"
+
+msgid "The secret number is: 83"
+msgstr "Le nombre secret est : 83"
+
+msgid "You guessed: 5"
+msgstr "Votre nombre : 5"
+
 
 #: src/ch02-00-guessing-game-tutorial.md:751
 msgid ""
@@ -4184,6 +4018,9 @@ msgstr ""
 msgid "// --snip--\n"
 msgstr "// -- partie masquée ici --\n"
 
+msgid "    match guess.cmp(&secret_number) {"
+msgstr "    match supposition.cmp(&nombre_secret) {"
+
 #: src/ch02-00-guessing-game-tutorial.md:787
 #: src/ch02-00-guessing-game-tutorial.md:912
 #: src/ch02-00-guessing-game-tutorial.md:1040
@@ -4195,7 +4032,10 @@ msgstr "// -- partie masquée ici --\n"
 #: src/ch09-03-to-panic-or-not-to-panic.md:193
 #: src/ch20-03-advanced-types.md:264
 msgid "\"Too small!\""
-msgstr "\"C'est plus !\""
+msgstr "\"C'est plus !\""
+
+msgid "Too small!"
+msgstr "C'est plus !"
 
 #: src/ch02-00-guessing-game-tutorial.md:788
 #: src/ch02-00-guessing-game-tutorial.md:913
@@ -4208,7 +4048,10 @@ msgstr "\"C'est plus !\""
 #: src/ch09-03-to-panic-or-not-to-panic.md:194
 #: src/ch20-03-advanced-types.md:265
 msgid "\"Too big!\""
-msgstr "\"C'est moins !\""
+msgstr "\"C'est moins !\""
+
+msgid "Too big!"
+msgstr "C'est moins !"
 
 #: src/ch02-00-guessing-game-tutorial.md:789
 #: src/ch02-00-guessing-game-tutorial.md:914
@@ -4221,7 +4064,10 @@ msgstr "\"C'est moins !\""
 #: src/ch09-03-to-panic-or-not-to-panic.md:196
 #: src/ch20-03-advanced-types.md:267
 msgid "\"You win!\""
-msgstr "\"Vous avez gagné !\""
+msgstr "\"Vous avez gagné !\""
+
+msgid "You win!"
+msgstr "Vous avez gagné !"
 
 #: src/ch02-00-guessing-game-tutorial.md:796
 msgid ""
@@ -4317,40 +4163,25 @@ msgstr ""
 msgid "However, the code in Listing 2-4 won’t compile yet. Let’s try it:"
 msgstr ""
 "Cependant, notre code dans l'encart 2-4 ne compile pas encore. Essayons de "
-"le faire :"
+"le faire :"
 
 #: src/ch02-00-guessing-game-tutorial.md:840
-msgid ""
-"```console\n"
-"$ cargo build\n"
-"   Compiling libc v0.2.86\n"
-"   Compiling getrandom v0.2.2\n"
-"   Compiling cfg-if v1.0.0\n"
-"   Compiling ppv-lite86 v0.2.10\n"
-"   Compiling rand_core v0.6.2\n"
-"   Compiling rand_chacha v0.3.0\n"
-"   Compiling rand v0.8.5\n"
-"   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"error[E0308]: mismatched types\n"
-"  --> src/main.rs:23:21\n"
-"   |\n"
-"23 |     match guess.cmp(&secret_number) {\n"
-"   |                 --- ^^^^^^^^^^^^^^ expected `&String`, found `&{integer}"
-"`\n"
-"   |                 |\n"
-"   |                 arguments to this method are incorrect\n"
-"   |\n"
-"   = note: expected reference `&String`\n"
-"              found reference `&{integer}`\n"
-"note: method defined here\n"
-"  --> /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/"
-"cmp.rs:979:8\n"
-"\n"
-"For more information about this error, try `rustc --explain E0308`.\n"
-"error: could not compile `guessing_game` (bin \"guessing_game\") due to 1 "
-"previous error\n"
-"```"
-msgstr ""
+
+msgid "23 |     match guess.cmp(&secret_number) {"
+msgstr "23 |     match supposition.cmp(&nombre_secret) {"
+
+# This is just for the fancy layout from cargo:
+msgid "   |                 --- ^^^^^^^^^^^^^^ expected `&String`, found `&{integer}`"
+msgstr "   |                       --- ^^^^^^^^^^^^^^ expected `&String`, found `&{integer}`"
+
+msgid "   |                 |"
+msgstr "   |                       |"
+
+msgid "   |                 arguments to this method are incorrect"
+msgstr "   |                       arguments to this method are incorrect"
+
+msgid "error: could not compile `guessing_game` (bin \"guessing_game\") due to 1 previous error"
+msgstr "error: could not compile `jeu_du_plus_ou_du_moins` (bin \"jeu_du_plus_ou_du_moins\") due to 1 previous error"
 
 #: src/ch02-00-guessing-game-tutorial.md:867
 msgid ""
@@ -4397,9 +4228,8 @@ msgstr ""
 #: src/ch02-00-guessing-game-tutorial.md:1035
 #: src/ch02-00-guessing-game-tutorial.md:1129
 #: src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md:409
-msgid "\"Please type a number!\""
-msgstr ""
-"\"Veuillez entrer un nombre !\""
+# msgid "\"Please type a number!\""
+# msgstr "\"Veuillez entrer un nombre !\""
 
 #: src/ch02-00-guessing-game-tutorial.md:919
 msgid "The line is:"
@@ -4418,35 +4248,27 @@ msgid ""
 "another type."
 msgstr ""
 "Nous créons une variable qui s'appelle `"
-"guess"
+"supposition"
 "`. Mais attendez, le "
 "programme n'a-t-il pas déjà une variable qui s'appelle `"
-"guess"
+"supposition"
 "` ? C'est "
 "le cas, mais heureusement Rust nous permet de _masquer_ la valeur précédente "
 "de `"
-"guess"
+"supposition"
 "` avec une nouvelle. Le masquage _(shadowing)_ nous permet de "
 "réutiliser le nom de variable `"
-"guess"
+"supposition"
 "`, plutôt que de nous forcer à "
 "créer deux variables distinctes, telles que `"
-"guess_str"
+"supposition_str"
 "` et `"
-"guess"
+"supposition"
 "` par exemple. Nous verrons cela plus en détails au [chapitre 3]"
 "(ch03-01-variables-and-mutability.html#shadowing)"
 "<!-- ignore -->, mais pour le moment cette fonctionnalité est "
 "souvent utilisée dans des situations où on veut convertir une valeur d'un "
 "type à un autre."
-
-# "supposition"
-# "supposition"
-# "supposition"
-# "supposition"
-# "supposition_str"
-# "supposition"
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
 
 
 #: src/ch02-00-guessing-game-tutorial.md:933
@@ -4465,12 +4287,12 @@ msgid ""
 "resulting in just `5`."
 msgstr ""
 "Nous lions cette nouvelle variable à l'expression `"
-"guess"
+"supposition"
 ".trim().parse()`. Le `"
-"guess"
+"supposition"
 "` dans l'expression se réfère à "
 "la variable `"
-"guess"
+"supposition"
 "` initiale qui contenait la saisie utilisateur en "
 "tant que chaîne de caractères. La méthode `trim` sur une instance de "
 "`String` va enlever les espaces et autres _whitespaces_ au début et à la "
@@ -4481,19 +4303,13 @@ msgstr ""
 "fin de ligne à la chaîne de caractères. Par exemple, si l'utilisateur écrit "
 "<kbd>5</kbd> et appuie sur "
 "<kbd>entrée</kbd>, `"
-"guess"
+"supposition"
 "` aura alors cette valeur : "
-"`5\\\n"
+"`5\\n"
 "`.  Le `\\n` représente une fin de ligne (à noter que sur Windows, appuyer "
 "sur <kbd>entrée</kbd> résulte en un retour chariot "
 "suivi d'un saut de ligne, `\\r\\n`). La méthode `trim` enlève `\\n` et "
 "`\\r\\n`, il ne reste donc plus que `5`."
-
-# "supposition"
-# "supposition"
-# "supposition"
-# "supposition"
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
 
 
 #: src/ch02-00-guessing-game-tutorial.md:945
@@ -4512,9 +4328,9 @@ msgstr ""
 "convertit une chaîne de caractères vers un autre type. Ici, elle est "
 "utilisée pour convertir d'une chaîne vers un nombre. Nous devons indiquer à "
 "Rust le type exact de nombre que nous voulons en utilisant `let "
-"guess"
+"supposition"
 ": u32`.  Le deux-points (`:`) après `"
-"guess"
+"supposition"
 "` indique à Rust que nous "
 "voulons préciser le type de la variable. Rust embarque quelques types de "
 "nombres ; le `u32` utilisé ici est un entier non signé sur 32 bits.  C'est "
@@ -4522,10 +4338,8 @@ msgstr ""
 "d'autres types de nombres dans le [chapitre 3]"
 "(ch03-02-data-types.html#integer-types)<!-- ignore -->."
 
-# "supposition"
-# "supposition"
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
 # @# FIXME: URL above (../std/primitive.str.html#method.parse) points to a 404 page
+
 
 #: src/ch02-00-guessing-game-tutorial.md:953
 msgid ""
@@ -4535,14 +4349,11 @@ msgid ""
 "of the same type!"
 msgstr ""
 " De plus, l'annotation `u32` dans ce programme d'exemple et la comparaison avec `"
-"secret_number"
+"nombre_secret"
 "` permet à Rust d'en déduire que `"
-"secret_number"
-"` doit être lui aussi un `u32`. Donc maintenant, la comparaison se fera entre deux valeurs du même type !"
-
-# "nombre_secret"
-# "nombre_secret"
-# TODO revert to original French translation, when issue https://github.com/rust-lang-translations/translations/issues/32 is solved => un-untranslate msgstr above by uncommenting it and moving it up
+"nombre_secret"
+"` doit être lui aussi un `u32`. Donc maintenant, la comparaison se fera entre "
+"deux valeurs du même type !"
 
 
 #: src/ch02-00-guessing-game-tutorial.md:958
@@ -4581,32 +4392,12 @@ msgid "Let’s run the program now:"
 msgstr "Exécutons ce programme, maintenant :"
 
 #: src/ch02-00-guessing-game-tutorial.md:980
-msgid ""
-"```console\n"
-"$ cargo run\n"
-"   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.26s\n"
-"     Running `target/debug/guessing_game`\n"
-"Guess the number!\n"
-"The secret number is: 58\n"
-"Please input your guess.\n"
-"  76\n"
-"You guessed: 76\n"
-"Too big!\n"
-"```"
-msgstr ""
-"```console\n"
-"$ cargo run\n"
-"   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.26s\n"
-"     Running `target/debug/guessing_game`\n"
-"Devinez le nombre !\n"
-"Le nombre secret est : 58\n"
-"Veuillez entrer un nombre.\n"
-"  76\n"
-"Votre nombre : 76\n"
-"C'est moins !\n"
-"```"
+msgid "The secret number is: 58"
+msgstr "Le nombre secret est : 58"
+
+msgid "You guessed: 76"
+msgstr "Votre nombre : 76"
+
 
 #: src/ch02-00-guessing-game-tutorial.md:993
 msgid ""
@@ -4642,6 +4433,11 @@ msgstr ""
 "Le mot-clé `loop` crée une boucle infinie. Nous allons ajouter une boucle "
 "pour donner aux utilisateurs plus de chances de deviner le nombre :"
 
+
+msgid "            .read_line(&mut guess)"
+msgstr "            .read_line(&mut supposition)"
+
+
 #: src/ch02-00-guessing-game-tutorial.md:1048
 msgid ""
 "As you can see, we’ve moved everything from the guess input prompt onward "
@@ -4676,62 +4472,23 @@ msgstr ""
 "procéder ainsi pour permettre à l'utilisateur de quitter, comme ci-dessous :"
 
 #: src/ch02-00-guessing-game-tutorial.md:1070
-msgid ""
-"```console\n"
-"$ cargo run\n"
-"   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s\n"
-"     Running `target/debug/guessing_game`\n"
-"Guess the number!\n"
-"The secret number is: 59\n"
-"Please input your guess.\n"
-"45\n"
-"You guessed: 45\n"
-"Too small!\n"
-"Please input your guess.\n"
-"60\n"
-"You guessed: 60\n"
-"Too big!\n"
-"Please input your guess.\n"
-"59\n"
-"You guessed: 59\n"
-"You win!\n"
-"Please input your guess.\n"
-"quit\n"
-"\n"
-"thread 'main' panicked at src/main.rs:28:47:\n"
-"Please type a number!: ParseIntError { kind: InvalidDigit }\n"
-"note: run with `RUST_BACKTRACE=1` environment variable to display a "
-"backtrace\n"
-"```"
-msgstr ""
-"```console\n"
-"$ cargo run\n"
-"   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s\n"
-"     Running `target/debug/guessing_game`\n"
-"Devinez le nombre !\n"
-"Le nombre secret est : 59\n"
-"Veuillez entrer un nombre.\n"
-"45\n"
-"Votre nombre : 45\n"
-"C'est plus !\n"
-"Veuillez entrer un nombre.\n"
-"60\n"
-"Votre nombre : 60\n"
-"C'est moins !\n"
-"Veuillez entrer un nombre.\n"
-"59\n"
-"Votre nombre : 59\n"
-"You win!\n"
-"Veuillez entrer un nombre.\n"
-"quit\n"
-"\n"
-"thread 'main' panicked at src/main.rs:28:47:\n"
-"thread 'main' panicked at 'Veuillez entrer un nombre!: ParseIntError { kind: InvalidDigit }\n"
-"note: run with `RUST_BACKTRACE=1` environment variable to display a "
-"backtrace\n"
-"```"
+msgid "The secret number is: 59"
+msgstr "Le nombre secret est : 59"
+
+msgid "You guessed: 45"
+msgstr "Votre nombre : 45"
+
+msgid "You guessed: 60"
+msgstr "Votre nombre : 60"
+
+msgid "You guessed: 59"
+msgstr "Votre nombre : 59"
+
+msgid "        match guess.cmp(&secret_number) {"
+msgstr "        match supposition.cmp(&nombre_secret) {"
+
+msgid "Please type a number!: ParseIntError { kind: InvalidDigit }"
+msgstr "Veuillez entrer un nombre !: ParseIntError { kind: InvalidDigit }"
 
 #: src/ch02-00-guessing-game-tutorial.md:1097
 msgid ""
@@ -4785,6 +4542,9 @@ msgstr ""
 "l'utilisateur puisse continuer à essayer de deviner. Nous pouvons faire ceci "
 "en modifiant la ligne où `supposition` est converti d'une `String` en un "
 "`u32`, comme dans l'encart 2-5 :"
+
+msgid "        let guess: u32 = match guess.trim().parse() {"
+msgstr "        let supposition: u32 = match supposition.trim().parse() {"
 
 #: src/ch02-00-guessing-game-tutorial.md:1207
 msgid ""
@@ -4848,52 +4608,18 @@ msgstr ""
 "Maintenant, le programme devrait fonctionner correctement. Essayons-le :"
 
 #: src/ch02-00-guessing-game-tutorial.md:1240
-msgid ""
-"```console\n"
-"$ cargo run\n"
-"   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s\n"
-"     Running `target/debug/guessing_game`\n"
-"Guess the number!\n"
-"The secret number is: 61\n"
-"Please input your guess.\n"
-"10\n"
-"You guessed: 10\n"
-"Too small!\n"
-"Please input your guess.\n"
-"99\n"
-"You guessed: 99\n"
-"Too big!\n"
-"Please input your guess.\n"
-"foo\n"
-"Please input your guess.\n"
-"61\n"
-"You guessed: 61\n"
-"You win!\n"
-"```"
-msgstr ""
-"```console\n"
-"$ cargo run\n"
-"   Compiling guessing_game v0.1.0 (file:///projects/guessing_game)\n"
-"    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s\n"
-"     Running `target/debug/guessing_game`\n"
-"Veuillez entrer un nombre.\n"
-"Le nombre secret est : 61\n"
-"Veuillez entrer un nombre.\n"
-"10\n"
-"Votre nombre : 10\n"
-"C'est plus !\n"
-"Veuillez entrer un nombre.\n"
-"99\n"
-"Votre nombre : 99\n"
-"C'est moins !\n"
-"Veuillez entrer un nombre.\n"
-"foo\n"
-"Veuillez entrer un nombre.\n"
-"61\n"
-"Votre nombre : 61\n"
-"Vous avez gagné !\n"
-"```"
+msgid "The secret number is: 61"
+msgstr "Le nombre secret est : 61"
+
+msgid "You guessed: 10"
+msgstr "Votre nombre : 10"
+
+msgid "You guessed: 99"
+msgstr "Votre nombre : 99"
+
+msgid "You guessed: 61"
+msgstr "Votre nombre : 61"
+
 
 #: src/ch02-00-guessing-game-tutorial.md:1263
 msgid ""
@@ -4911,7 +4637,7 @@ msgstr ""
 #: src/ch02-00-guessing-game-tutorial.md:1311
 msgid ""
 "At this point, you’ve successfully built the guessing game. Congratulations!"
-msgstr ""
+msgstr "Si vous êtes arrivé jusqu'ici, c'est que vous avez construit avec succès le jeu du plus ou du moins. Félicitations !"
 
 #: src/ch02-00-guessing-game-tutorial.md:1315
 msgid ""
@@ -4989,6 +4715,9 @@ msgstr ""
 "fonctionnalité active pour le moment, mais ont été réservés pour être "
 "ajoutés plus tard à Rust. Vous pouvez trouver la liste de ces mots-clés "
 "dans > [l'annexe A](appendix-01-keywords.md)<!-- ignore -->."
+
+# }}}
+# Les variables et la mutabilité {{{
 
 #: src/ch03-01-variables-and-mutability.md:3
 msgid ""


### PR DESCRIPTION
The original French translation had variables, structs, etc. translated in the code examples, matching translations in the body text.

Using modifications in [pull request 34](https://github.com/rust-lang-translations/translations/pull/34), the codes included in the final document can be translated, therefore the original translation can also be kept.