### PR TITLE
French rustbook checks corrections

### DIFF
--- a/translations/book/fr.po
+++ b/translations/book/fr.po
@@ -1227,6 +1227,7 @@ msgstr ""
 # Old version of previous paragraph:
 # "La version française est aussi disponible sur [GitHub](https://github.com/Jimskapt/rust-book-fr)."
 # @# TODO eventually, put this sentence back with the rust-lang-translations.org URL
+# TODO ajouter https://titome.github.io/rust-book-fr/
 
 
 # }}}

--- a/translations/book/fr.po
+++ b/translations/book/fr.po
@@ -4259,20 +4259,48 @@ msgstr "Encart 2-3 : Ajout du code pour générer un nombre aléatoire"
 # FIXME: the legends as the one above are not translated
 
 
-#: src/ch02-00-guessing-game-tutorial.md:689
-msgid ""
-"First, we add the line `use rand::prelude::*;`. The `prelude` module "
-"contains the most commonly used parts of the `rand` crate, and `use` makes "
-"those items available in our program's scope."
-msgstr ""
-"D'abord, nous avons ajouté la ligne `use rand::prelude::*;`. Le module "
-"`prelude` contient les éléments les plus couramment utilisés de la crate "
-"`rand`, et `use` permet de rendre ces éléments disponibles dans la portée de "
-"notre programme."
+# PROBLEMATIC PARAGRAPH: {{{
+# #: src/ch02-00-guessing-game-tutorial.md:689
+# msgid ""
+# "First, we add the line `use rand::prelude::*;`. The `prelude` module "
+# "contains the most commonly used parts of the `rand` crate, and `use` makes "
+# "those items available in our program's scope."
+# msgstr ""
+# "D'abord, nous avons ajouté la ligne `use rand::prelude::*;`. Le module "
+# "`prelude` contient les éléments les plus couramment utilisés de la crate "
+# "`rand`, et `use` permet de rendre ces éléments disponibles dans la portée de "
+# "notre programme."
 
 # FIXME paragraph above is not translated, albeit the msgid being the same as 
 #       the one in the messages.pot which was generated
 
+# Autres tests:
+
+# # Copié-collé depuis le markdown ~/heaume_pierre/developpt/rust_book_translations/repos/rust/src/doc/book/src/ch02-00-guessing-game-tutorial.md
+# msgid ""
+# "First, we add the line `use rand::prelude::*;`. The `prelude` module contains "
+# "the most commonly used parts of the `rand` crate, and `use` makes those items "
+# "available in our program's scope."
+# msgstr ""
+# "TRADUCTION DEPUIS MARKDOWN"
+# # => ne fonctionne pas
+
+# # Copié-collé depuis le messages.pot généré par cargo run:
+# msgid ""
+# "First, we add the line `use rand::prelude::*;`. The `prelude` module "
+# "contains the most commonly used parts of the `rand` crate, and `use` makes "
+# "those items available in our program's scope."
+# msgstr ""
+# "TRADUCTION DEPUIS MESSAGES.POT"
+# # => ne fonctionne pas
+
+# # Copié-collé depuis le markdown ~/heaume_pierre/developpt/rust_book_translations/repos/rust/src/doc/book/src/ch02-00-guessing-game-tutorial.md en une ligne:
+msgid ""
+"First, we add the line `use rand::prelude::*;`. The `prelude` module contains the most commonly used parts of the `rand` crate, and `use` makes those items available in our program's scope."
+msgstr "TRADUCTION DEPUIS MARKDOWN"
+
+
+# }}}
 
 #: src/ch02-00-guessing-game-tutorial.md:696
 msgid ""
@@ -10795,7 +10823,7 @@ msgid ""
 "problems.\n"
 msgstr ""
 "// r1 sort de la portée ici, donc nous pouvons créer une nouvelle référence\n"
-"      // sans problème."
+"      // sans problème.\n"
 
 #: src/ch04-02-references-and-borrowing.md:243
 msgid ""

--- a/translations/book/fr.po
+++ b/translations/book/fr.po
@@ -1958,10 +1958,10 @@ msgstr ""
 "répertoire _projects_ et un répertoire pour le projet “Hello, world!” à "
 "l'intérieur de ce répertoire _projects_."
 
-# @# TODO: GNU should be added in upstream English text, and also capital MacOS
+# TODO: GNU should be added in upstream English text
 #: src/ch01-02-hello-world.md:28
 msgid "For Linux, macOS, and PowerShell on Windows, enter this:"
-msgstr "Sous GNU/Linux, MacOS et PowerShell sous Windows, écrivez ceci :"
+msgstr "Sous GNU/Linux, macOS et PowerShell sous Windows, écrivez ceci :"
 
 #: src/ch01-02-hello-world.md:37
 msgid "For Windows CMD, enter this:"

--- a/translations/book/fr.po
+++ b/translations/book/fr.po
@@ -4259,48 +4259,27 @@ msgstr "Encart 2-3 : Ajout du code pour générer un nombre aléatoire"
 # FIXME: the legends as the one above are not translated
 
 
-# PROBLEMATIC PARAGRAPH: {{{
-# #: src/ch02-00-guessing-game-tutorial.md:689
-# msgid ""
-# "First, we add the line `use rand::prelude::*;`. The `prelude` module "
-# "contains the most commonly used parts of the `rand` crate, and `use` makes "
-# "those items available in our program's scope."
-# msgstr ""
-# "D'abord, nous avons ajouté la ligne `use rand::prelude::*;`. Le module "
-# "`prelude` contient les éléments les plus couramment utilisés de la crate "
-# "`rand`, et `use` permet de rendre ces éléments disponibles dans la portée de "
-# "notre programme."
-
-# FIXME paragraph above is not translated, albeit the msgid being the same as 
-#       the one in the messages.pot which was generated
-
-# Autres tests:
-
-# # Copié-collé depuis le markdown ~/heaume_pierre/developpt/rust_book_translations/repos/rust/src/doc/book/src/ch02-00-guessing-game-tutorial.md
-# msgid ""
-# "First, we add the line `use rand::prelude::*;`. The `prelude` module contains "
-# "the most commonly used parts of the `rand` crate, and `use` makes those items "
-# "available in our program's scope."
-# msgstr ""
-# "TRADUCTION DEPUIS MARKDOWN"
-# # => ne fonctionne pas
-
-# # Copié-collé depuis le messages.pot généré par cargo run:
-# msgid ""
-# "First, we add the line `use rand::prelude::*;`. The `prelude` module "
-# "contains the most commonly used parts of the `rand` crate, and `use` makes "
-# "those items available in our program's scope."
-# msgstr ""
-# "TRADUCTION DEPUIS MESSAGES.POT"
-# # => ne fonctionne pas
-
-# # Copié-collé depuis le markdown ~/heaume_pierre/developpt/rust_book_translations/repos/rust/src/doc/book/src/ch02-00-guessing-game-tutorial.md en une ligne:
 msgid ""
-"First, we add the line `use rand::prelude::*;`. The `prelude` module contains the most commonly used parts of the `rand` crate, and `use` makes those items available in our program's scope."
-msgstr "TRADUCTION DEPUIS MARKDOWN"
+"First, we add the line `use rand::prelude::*;`. The `prelude` module "
+"contains the most commonly used parts of the `rand` crate, and `use` makes "
+"those items available in our program’s scope."
+msgstr ""
+"D'abord, nous avons ajouté la ligne `use rand::prelude::*;`. Le module "
+"`prelude` contient les éléments les plus couramment utilisés de la crate "
+"`rand`, et `use` permet de rendre ces éléments disponibles dans la portée de "
+"notre programme."
 
+# FIXED paragraph above is not translated, albeit the msgid being the same as 
+#       the one in the messages.pot which was generated
+# => FIXED, that was caused by the ’ which used to be a ', and is also a ' in 
+#           the markdown in:
+#           repos/rust/src/doc/book/src/ch02-00-guessing-game-tutorial.md
+#           , so:
+# =>
+# FIXME add a tolerance, in the process, for ’ vs. '; since the ' seem to be
+#       translated to ’ during the HTML generation, this shouldn't affect the
+#       whole process
 
-# }}}
 
 #: src/ch02-00-guessing-game-tutorial.md:696
 msgid ""
@@ -5632,8 +5611,8 @@ msgstr ""
 
 #: src/ch03-01-variables-and-mutability.md:216
 #: src/ch03-01-variables-and-mutability.md:229
-msgid "    let spaces = "   ";"
-msgstr "    let espaces = "   ";"
+msgid "    let spaces = \"   \";"
+msgstr "    let espaces = \"   \";"
 
 msgid "    let spaces = spaces.len();"
 msgstr "    let espaces = espaces.len();"
@@ -5653,8 +5632,8 @@ msgstr ""
 "le nom `espaces`. Cependant, si nous essayons d'utiliser `mut` pour faire "
 "ceci, comme ci-dessous, nous avons une erreur de compilation :"
 
-msgid "    let mut spaces = "   ";"
-msgstr "    let mut espaces = "   ";"
+msgid "    let mut spaces = \"   \";"
+msgstr "    let mut espaces = \"   \";"
 
 msgid "    spaces = spaces.len();"
 msgstr "    espaces = espaces.len();"
@@ -14791,7 +14770,7 @@ msgstr "`Quitter` : n'a pas du tout de donnée associée."
 msgid "`Move`: Has named fields, like a struct does"
 msgstr "`Deplacer` : a des champs nommés, à l'instar d'une structure."
 
-#"`Deplacer` : intègre une structure anonyme en son sein."
+# "`Deplacer` : intègre une structure anonyme en son sein."
 
 
 #: src/ch06-01-defining-an-enum.md:253
@@ -48786,7 +48765,7 @@ msgstr ""
 "d'agir avec le mot-clé `await` (en fait, Rust indiquera un avertissement du "
 "compilateur si vous n'utilisez pas une future). Ceci pourrait vous rappeler "
 "la discussion à propos des itérateurs dans la section [“Traiter une série "
-"d’éléments avec des itérateurs”](ch13-02-iterators.html)""<!-- ignore --> du "
+"d’éléments avec des itérateurs”](ch13-02-iterators.html)<!-- ignore --> du "
 "chapitre 13. Les itérateurs ne font rien jusqu'à ce que vous appeliez leur "
 "méthode `next` — soit directement, soit en utilisant des boucles `for` ou "
 "des méthodes comme `map` qui utilisent `next` sous le capot. De même, les "
@@ -54200,9 +54179,9 @@ msgstr ""
 "    billet.ajouter_texte(\"J'ai mangé une salade au déjeuner aujourd'hui\");"
 
 msgid ""
-"    assert_eq!("", post.content());"
+"    assert_eq!(\"\", post.content());"
 msgstr ""
-"    assert_eq!("", billet.contenu());"
+"    assert_eq!(\"\", billet.contenu());"
 
 msgid ""
 "    post.request_review();"

--- a/translations/book/fr.po
+++ b/translations/book/fr.po
@@ -531,8 +531,9 @@ msgstr "Arrêt propre et nettoyage"
 msgid "Appendix"
 msgstr "Annexes"
 
-# FIXME title in upstream should be plural, shouldn't it?
+# FIXED title in upstream should be plural, shouldn't it?
 #       Appendix => Appendices
+# => see commit 3a6e0450f2efb4a58ea329494f63d588052406c2 in our branch from upstream
 
 
 #: src/SUMMARY.md:129
@@ -1176,11 +1177,11 @@ msgstr "Ce code ne compile pas !"
 # "<img src=\"img/ferris/panics.svg\" class=\"ferris-explain\" alt=\"ferris "
 # "qui lève ses bras\"/>"
 msgid ""
-"ferris throwing up their hands"
+"Ferris throwing up its hands"
 msgstr "Ferris levant les bras"
 
-# @# TODO: capital F for ferris should be corrected in upstream English text
-# @# TODO: in upstream English text, correct "their hands" => "its hands"
+# DONE: in upstream English text, correct "their hands" => "its hands"
+# => see commit febd934dda8d2ca2693fc144e3d37e7a4c203006 in our branch from upstream 
 
 
 #: src/ch00-00-introduction.md:190
@@ -1560,8 +1561,8 @@ msgstr ""
 "aventure doit commencer quelque part. Dans ce chapitre, nous allons aborder :"
 
 #: src/ch01-00-getting-started.md:6
-msgid "Installing Rust on Linux, macOS, and Windows"
-msgstr "Installation de Rust sur Linux, macOS et Windows"
+msgid "Installing Rust on GNU/Linux, macOS, and Windows"
+msgstr "Installation de Rust sur GNU/Linux, macOS et Windows"
 
 #: src/ch01-00-getting-started.md:7
 msgid "Writing a program that prints `Hello, world!`"
@@ -1640,14 +1641,14 @@ msgstr ""
 
 #: src/ch01-01-installation.md:26
 msgid "Installing `rustup` on Linux or macOS"
-msgstr "Installer `rustup` sur Linux ou macOS"
+msgstr "Installer `rustup` sur GNU/Linux ou macOS"
 
 #: src/ch01-01-installation.md:28
 msgid ""
 "If you’re using Linux or macOS, open a terminal and enter the following "
 "command:"
 msgstr ""
-"Si vous utilisez Linux ou macOS, ouvrez un terminal et écrivez la commande "
+"Si vous utilisez GNU/Linux ou macOS, ouvrez un terminal et écrivez la commande "
 "suivante :"
 
 #: src/ch01-01-installation.md:30
@@ -1696,7 +1697,7 @@ msgid ""
 "distribution’s documentation. For example, if you use Ubuntu, you can "
 "install the `build-essential` package."
 msgstr ""
-"Les utilisateurs de Linux doivent généralement installer GCC ou Clang, en "
+"Les utilisateurs de GNU/Linux doivent généralement installer GCC ou Clang, en "
 "fonction de la documentation de leur distribution. Par exemple, si vous "
 "utilisez Ubuntu, vous pouvez installer le paquet `build-essential`."
 
@@ -1774,7 +1775,7 @@ msgstr "Dans le terminal CMD de Windows, entrez :"
 msgid "In PowerShell, use:"
 msgstr "Dans PowerShell, entrez :"
 
-# @# TODO: GNU should be added in upstream English text
+# DONE: GNU should be added in upstream English text
 #: src/ch01-01-installation.md:103
 msgid "In Linux and macOS, use:"
 msgstr "Sous GNU/Linux et macOS, entrez :"
@@ -1958,7 +1959,8 @@ msgstr ""
 "répertoire _projects_ et un répertoire pour le projet “Hello, world!” à "
 "l'intérieur de ce répertoire _projects_."
 
-# TODO: GNU should be added in upstream English text
+# DONE: GNU should be added in upstream English text
+# => see commit ae287193ac37139a39cbee3bcb5f3af27f1ac8cb in our branch from upstream 
 #: src/ch01-02-hello-world.md:28
 msgid "For Linux, macOS, and PowerShell on Windows, enter this:"
 msgstr "Sous GNU/Linux, macOS et PowerShell sous Windows, écrivez ceci :"
@@ -2097,7 +2099,7 @@ msgid ""
 "compile and run the file:"
 msgstr ""
 "Enregistrez le fichier et retournez dans votre terminal dans le répertoire "
-"_~/projects/hello_world_. Sur Linux ou macOS, écrivez les commandes "
+"_~/projects/hello_world_. Sur GNU/Linux ou macOS, écrivez les commandes "
 "suivantes pour compiler et exécuter le fichier :"
 
 #: src/ch01-02-hello-world.md:78
@@ -2106,14 +2108,15 @@ msgstr ""
 "Sur Windows, écrivez la commande `.\\main.exe` à la place de `./main` :"
 
 # <!--
-# @# TODO there's a misteack in the upstream English version: make a PR to
+#    DONE there's a misteack in the upstream English version: make a PR to
 #         correct it
 # On Windows, enter the command `.\main` instead of `./main`:
 # => add missing .exe extension:
 # On Windows, enter the command `.\main.exe` instead of `./main`:
 #
-# @# TODO Also correct the powershell terminal in the same PR
+#    DONE Also correct the powershell terminal in the same PR
 # -->
+# => see commit 037782bca8b6034035553eb94204c909c73cec6e in our branch from upstream
 
 
 #: src/ch01-02-hello-world.md:86
@@ -2287,7 +2290,7 @@ msgid ""
 "On Linux, macOS, and PowerShell on Windows, you can see the executable by "
 "entering the `ls` command in your shell:"
 msgstr ""
-"Avec Linux, macOS et PowerShell sous Windows, vous pouvez voir l'exécutable "
+"Avec GNU/Linux, macOS et PowerShell sous Windows, vous pouvez voir l'exécutable "
 "en utilisant la commande `ls` dans votre terminal :"
 
 #: src/ch01-02-hello-world.md:175
@@ -2296,7 +2299,7 @@ msgid ""
 "see the same three files that you would see using CMD. With CMD on Windows, "
 "you would enter the following:"
 msgstr ""
-"Avec Linux et macOS, vous devriez voir deux fichiers. Avec PowerShell sous "
+"Avec GNU/Linux et macOS, vous devriez voir deux fichiers. Avec PowerShell sous "
 "Windows, vous devriez voir les trois mêmes fichiers que vous verriez en "
 "utilisant CMD. Avec CMD sous Windows, vous devez saisir la commande "
 "suivante :"
@@ -2860,7 +2863,7 @@ msgid ""
 msgstr ""
 "Un autre avantage d'utiliser Cargo est que les commandes sont les mêmes peu "
 "importe le système d'exploitation que vous utilisez. Donc à partir de "
-"maintenant, nous n'allons plus faire d'opérations spécifiques à Linux et "
+"maintenant, nous n'allons plus faire d'opérations spécifiques à GNU/Linux et "
 "macOS par rapport à Windows."
 
 #: src/ch01-03-hello-cargo.md:206
@@ -48010,12 +48013,14 @@ msgstr ""
 "asynchrone, et le projet du chapitre 21 va utiliser ces concepts dans une "
 "situation plus réaliste que les petits exemples que nous avons utilisés ici."
 
-# FIXME: in the previous paragraph, the English sentence should be rephrased:
+# FIXED: in the previous paragraph, the English sentence should be rephrased:
 #
 # , and the project in Chapter 21 will use the concepts in this chapter in a more realistic situation than
 # , and the project in Chapter 21 will use these concepts in a more realistic situation than
 #
 # TODO update upstream version
+# => see commit 178c4ffe3498c8472d0ccf1a982a42a7f5fc638d in our branch from upstream
+
 
 #: src/ch16-04-extensible-concurrency-sync-and-send.md:85
 msgid ""
@@ -48390,9 +48395,15 @@ msgstr ""
 "tâche A3 soit bloquée par l'attente des résultats de la tâche B3"
 
 # FIXME legend above is not translated
-# FIXME in English upstream version:
+# FIXED in English upstream version (more specifically in our contribution):
 #         - improve last part of sentence
 #         - get rid of point at end of legend above
+# => see commit 178c4ffe3498c8472d0ccf1a982a42a7f5fc638d in our branch from upstream
+#
+# FIXME later, improve French version so as to match modified English upstream:
+# "Figure 17-3 : un flux de travail partiellement parallèle, où le travail se "
+# "fait indépendamment sur les tâches A et B jusqu'à ce que la tâche A3 doive "
+# "attendre les résultats de la tâche B3"
 
 
 #: src/ch17-00-async-await.md:144
@@ -52232,13 +52243,15 @@ msgstr ""
 "ignore --> de [_Asynchronous Programming in Rust_](https://rust-lang."
 "github.io/async-book/)."
 
-# FIXME - the URL "2" from the English upstream version points to the section 
+# FIXED - the URL "2" from the English upstream version points to the section 
 #         "Old chapters" of the "Asynchronous Programming in Rust" pages
 #         => make it point to a more up-to-date URL
+#            => fixed "by itself"
 #       - the URL "4" from the same upstream version points to a 404
 #         => make it point to a valid URL:
 #            https://rust-lang.github.io/async-book/part-reference/pinning.html
 #            (double-check this URL is appropriate)
+# => see commit bc5a73c827e1e9756443078f124d8ac05cd30e5f in our branch from upstream
 
 
 #: src/ch17-05-traits-for-async.md:545
@@ -65621,7 +65634,8 @@ msgstr ""
 "constaterez que _/_ attend que `pause` ait fini sa pause de cinq secondes "
 "avant de se charger."
 
-# TODO add the URIs as links, for commodity, in the upstream English version
+# DONE add the URIs as links, for commodity, in the upstream English version
+# => see commit 343617d11f0466dcad6eee2644d79b954d401896 in our branch from upstream
 
 
 #: src/ch21-02-multithreaded.md:97
@@ -70594,9 +70608,9 @@ msgstr ""
 "laquelle aucun code arbitraire n'est exécuté. Ainsi, tous les programmeurs "
 "peuvent présupposer que la copie d'une valeur sera très rapide."
 
-# TODO add the idea "volontairement" => "on purpose" or "willingly" to
+# DONE add the idea "volontairement" => "on purpose" or "willingly" to
 #      English upstream
-
+# => see commit cea5ac45ecca6d731fcff2289761539edb8edda5 in our branch from upstream
 
 #: src/appendix-03-derivable-traits.md:138
 msgid ""
@@ -71002,6 +71016,9 @@ msgstr ""
 "items?itemName=rust-lang.rust-analyzer)."
 
 # FIXME the \n above should probably be removed from upstream
+#       This case happens quite often throughout the book (20 occurrences),
+#       a more general solution should be sought, probably during the process
+#       of reading the Markdown.
 
 
 #: src/appendix-04-useful-development-tools.md:159
@@ -74318,5 +74335,9 @@ msgstr ""
 # @#
 # TODO
 # NOTE
+# FIXED
 # FIXME
 
+# Things to look for after English commits will be merged, to realign msgids:
+# GNU/Linux
+# => see commit


### PR DESCRIPTION
While doing the maintenance of the French translation of the Book, there were a few things which deserved some corrections in the upstream English version of the Book.
These corrections are covered by [PR 4812](https://github.com/rust-lang/book/pull/4812).

Related comments were updated in `fr.po`, for traceability; some corrections were also made.

Once that upstream PR4812 will be treated, the `msgid` will have to be changed accordingly.